### PR TITLE
Concurrent wallet checks

### DIFF
--- a/balance/balance.go
+++ b/balance/balance.go
@@ -2,16 +2,21 @@ package balance
 
 import (
 	"time"
+
+	"github.com/square/beancounter/deriver"
 )
 
 // Checker is an interface wraps the Fetch method.
 // Checker fetches the balance information for an address.
 type Checker interface {
-	Fetch(addr string) (*Response, error)
+	Fetch(addr string) *Response
+	Subscribe(addrCh <-chan *deriver.Address) <-chan *Response
 }
 
 // Response wraps the balance and transaction information
 type Response struct {
+	Error        error
+	Address      *deriver.Address
 	Balance      uint64        `json:"balance"` // in Satoshi
 	Transactions []Transaction `json:"txrefs,omitempty"`
 }

--- a/balance/balance.go
+++ b/balance/balance.go
@@ -6,8 +6,10 @@ import (
 	"github.com/square/beancounter/deriver"
 )
 
-// Checker is an interface wraps the Fetch method.
+// Checker is an interface that wraps the Fetch method.
 // Checker fetches the balance information for an address.
+// It provides a simple Fetch API to check a single address and a Subscribe API
+// for continuous check of of address stream.
 type Checker interface {
 	Fetch(addr string) *Response
 	Subscribe(addrCh <-chan *deriver.Address) <-chan *Response

--- a/balance/block_cypher_checker.go
+++ b/balance/block_cypher_checker.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 
+	"github.com/square/beancounter/deriver"
 	"github.com/square/beancounter/utils"
 )
 
@@ -29,30 +31,64 @@ func NewBlockCypherChecker(network utils.Network) *BlockCypherChecker {
 
 // Fetch queries connected node for address balance and transaction history and
 // returns Response.
-func (b *BlockCypherChecker) Fetch(addr string) (*Response, error) {
+func (b *BlockCypherChecker) Fetch(addr string) *Response {
 	url := apiURL + b.chain() + "addrs/" + addr + "?limit=0"
 	resp, err := http.Get(url)
 	if err != nil {
-		return nil, err
+		return &Response{Error: err}
 	}
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("bad response: %+v", resp)
+		return &Response{Error: fmt.Errorf("bad response: %+v", resp)}
 	}
 
 	return decode(resp.Body)
 }
 
+// Subscribe provides a bidirectional streaming of checks for addresses.
+// It takes a channel of addresses and returns a channel of responses, to which
+// it is writing asynchronuously.
+// TODO: Looks like Subscribe implementation is separate from implementation
+//       details of each checker and therefore could be abstracted into a separate
+//       struct/interface (e.g. there could be a StreamingChecker interface that
+//       implements Subcribe method).
+func (b *BlockCypherChecker) Subscribe(addrCh <-chan *deriver.Address) <-chan *Response {
+	respCh := make(chan *Response, 100)
+	go func() {
+		var wg sync.WaitGroup
+		for addr := range addrCh {
+			wg.Add(1)
+			// do not block on each Fetch API call
+			b.processFetch(addr, respCh, &wg)
+		}
+		// ensure that all addresses are processed and written to the output channel
+		// before closing it.
+		wg.Wait()
+		close(respCh)
+	}()
+
+	return respCh
+}
+
+// processFetch fetches the data for an address, sends the response to the outgoing
+// channel and marks itself as done in the shared WorkGroup
+func (b *BlockCypherChecker) processFetch(addr *deriver.Address, out chan<- *Response, wg *sync.WaitGroup) {
+	resp := b.Fetch(addr.String())
+	resp.Address = addr
+	out <- resp
+	wg.Done()
+}
+
 // decode attempts to read data from the reader and decode it a BalanceResponse.
-func decode(resp io.Reader) (*Response, error) {
+func decode(resp io.Reader) *Response {
 	dec := json.NewDecoder(resp)
 	var r Response
 	err := dec.Decode(&r)
 	if err != nil {
-		return nil, err
+		return &Response{Error: err}
 	}
-	return &r, nil
+	return &r
 }
 
 // chain maps a Network type into a chain name used by BlockCypher in their API

--- a/balance/electrum_checker.go
+++ b/balance/electrum_checker.go
@@ -58,6 +58,13 @@ func (e *ElectrumChecker) Fetch(addr string) *Response {
 	return resp
 }
 
+// Subscribe provides a bidirectional streaming of checks for addresses.
+// It takes a channel of addresses and returns a channel of responses, to which
+// it is writing asynchronuously.
+// TODO: Looks like Subscribe implementation is separate from implementation
+//       details of each checker and therefore could be abstracted into a separate
+//       struct/interface (e.g. there could be a StreamingChecker interface that
+//       implements Subcribe method).
 func (e *ElectrumChecker) Subscribe(addrCh <-chan *deriver.Address) <-chan *Response {
 	respCh := make(chan *Response, 100)
 	go func() {
@@ -76,6 +83,8 @@ func (e *ElectrumChecker) Subscribe(addrCh <-chan *deriver.Address) <-chan *Resp
 	return respCh
 }
 
+// processFetch fetches the data for an address, sends the response to the outgoing
+// channel and marks itself as done in the shared WorkGroup
 func (e *ElectrumChecker) processFetch(addr *deriver.Address, out chan<- *Response, wg *sync.WaitGroup) {
 	resp := e.Fetch(addr.String())
 	resp.Address = addr

--- a/beancounter/beancounter.go
+++ b/beancounter/beancounter.go
@@ -1,0 +1,186 @@
+package beancounter
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/square/beancounter/balance"
+	"github.com/square/beancounter/deriver"
+	. "github.com/square/beancounter/utils"
+)
+
+type Beancounter struct {
+	account       string
+	net           Network
+	xpubs         []string
+	lastAddresses [2]uint32
+	totalBalance  uint64
+	transactions  []transaction
+	balances      []addrBalance
+	// NOTE: maybe track unconfirmed balance and fees. We might want to also track each transaction's amount and whether
+	// it's a credit or debit.
+
+	checker   balance.Checker
+	deriver   *deriver.AddressDeriver
+	lookahead uint32
+	sleep     time.Duration
+	wg        sync.WaitGroup
+
+	derivedCount uint32
+	checkedCount uint32
+	checkerCh    chan *deriver.Address
+	receivedCh   <-chan *balance.Response
+}
+
+func NewBalance(checker balance.Checker, drvr *deriver.AddressDeriver, lookahead uint32, sleep time.Duration) *Beancounter {
+	b := &Beancounter{
+		checker:       checker,
+		deriver:       drvr,
+		lookahead:     lookahead,
+		sleep:         sleep,
+		lastAddresses: [2]uint32{lookahead, lookahead},
+		checkerCh:     make(chan *deriver.Address, 100),
+	}
+	b.receivedCh = b.checker.Subscribe(b.checkerCh)
+	return b
+}
+
+func (b *Beancounter) Count() {
+	b.wg.Add(1)
+	go b.sendWork()
+	go b.receiveWork()
+	b.wg.Wait()
+}
+
+func (b *Beancounter) sendWork() {
+	indexes := []uint32{0, 0}
+	for {
+		for _, change := range []uint32{0, 1} {
+			for i := indexes[change]; i < b.lastAddresses[change]; i++ {
+				atomic.AddUint32(&b.derivedCount, 1)
+				b.checkerCh <- b.deriver.Derive(change, i)
+
+				indexes[change] = i
+				time.Sleep(b.sleep)
+			}
+			indexes[change]++
+		}
+		// apparently no more work for us, so we can sleep a bit
+		time.Sleep(time.Millisecond * 100)
+	}
+}
+
+func (b *Beancounter) receiveWork() {
+	b.receiveWorkLoop()
+	b.wg.Done()
+}
+
+func (b *Beancounter) receiveWorkLoop() {
+	for {
+		select {
+		case resp := <-b.receivedCh:
+			atomic.AddUint32(&b.checkedCount, 1)
+			if resp != nil {
+				b.AddBalance(resp)
+
+				fmt.Printf("Checking balance for %s %s ... ", resp.Address.Path(), resp.Address.String())
+				if resp.HasTransactions() {
+					fmt.Printf("%d %d\n", resp.Balance, b.totalBalance)
+				} else {
+					fmt.Printf("∅\n")
+				}
+			}
+		default:
+			// no work check if we're done
+			if b.Complete() {
+				return
+			}
+		}
+	}
+}
+
+func (b *Beancounter) Complete() bool {
+	indexes := b.lastAddresses[0] + b.lastAddresses[1]
+	return b.derivedCount == indexes && b.checkedCount == indexes
+}
+
+type addrBalance struct {
+	path    string
+	addr    string
+	balance uint64
+}
+
+func (b *addrBalance) toCSV() string {
+	return b.path + "," + b.addr + "," + strconv.FormatUint(b.balance, 10)
+}
+
+func (b *addrBalance) toArray() []string {
+	return []string{b.path, b.addr, strconv.FormatUint(b.balance, 10)}
+}
+
+type transaction struct {
+	path string
+	addr string
+	hash string
+}
+
+func (t *transaction) toCSV() string {
+	return t.path + "," + t.addr + "," + t.hash
+}
+
+func (t *transaction) toArray() []string {
+	return []string{t.path, t.addr, t.hash}
+}
+
+func (b *Beancounter) WriteTransactions() {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Path", "Address", "Transaction Hash"})
+
+	for _, b := range b.transactions {
+		table.Append(b.toArray())
+	}
+	table.Render()
+	fmt.Printf("\n")
+}
+
+func (b *Beancounter) WriteSummary() {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Total Balance", "Last Receive Index", "Last Change Index", "Report Time"})
+
+	table.Append([]string{
+		strconv.FormatUint(b.totalBalance, 10),
+		strconv.FormatUint(uint64(b.lastAddresses[0]-1), 10),
+		strconv.FormatUint(uint64(b.lastAddresses[1]-1), 10),
+		time.Now().Format(time.RFC822)})
+	table.Render()
+	fmt.Printf("\n")
+}
+
+func (b *Beancounter) WriteBalances() {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Path", "Address", "Balance"})
+
+	for _, b := range b.balances {
+		table.Append(b.toArray())
+	}
+	table.Render()
+	fmt.Printf("\n")
+}
+
+func (b *Beancounter) AddBalance(r *balance.Response) {
+	b.totalBalance += r.Balance
+	if r.HasTransactions() {
+		// move lookahead since we found a transaction
+		atomic.StoreUint32(&b.lastAddresses[r.Address.Change()], r.Address.Index()+b.lookahead)
+		b.balances = append(b.balances, addrBalance{path: r.Address.Path(), addr: r.Address.String(), balance: r.Balance})
+
+		for _, tx := range r.Transactions {
+			b.transactions = append(b.transactions, transaction{path: r.Address.Path(), addr: r.Address.String(), hash: tx.Hash})
+		}
+	}
+}

--- a/deriver/address_deriver_test.go
+++ b/deriver/address_deriver_test.go
@@ -15,7 +15,7 @@ func TestDeriveMultiSigSegwit(t *testing.T) {
 		"tpubD8GrNWdYHDjdJryH5tng8LUzHSrEo4gToaguKnzthEqTxyfF13jTsp4sMtmso4n1VC58R5Wvt4Ua4npZTecR1xaGGYJgLLQj5sQGdD2xh2N",
 	}
 	deriver := NewAddressDeriver(Testnet, xpubs, 2, 0)
-	assert.Equal(t, "2N4TmnHspa8wqFEUfxfjzHoSUAgwoUwNWhr", deriver.Derive(0, 0))
+	assert.Equal(t, "2N4TmnHspa8wqFEUfxfjzHoSUAgwoUwNWhr", deriver.Derive(0, 0).String())
 }
 
 func TestDeriveGateway(t *testing.T) {
@@ -23,6 +23,6 @@ func TestDeriveGateway(t *testing.T) {
 		"tpubD8L6UhrL8ML9Ao47k4pmdvUoiA6QUJVzrJ9BXLgU9idRKnvdRFGgjcxmVxojWGvCcjMi6QWCp8uMpCwWdSFRDNJ7utizxLy27sVWXQT4Jz7",
 	}
 	deriver := NewAddressDeriver(Testnet, xpubs, 1, 1234)
-	assert.Equal(t, "mzoeuyGqMudyvKbkNx5dtNBNN59oKEAsPn", deriver.Derive(0, 0))
-	assert.Equal(t, "moHN13u4RoMxujdaPxvuaTaawgWZ3LaGyo", deriver.Derive(1, 0))
+	assert.Equal(t, "mzoeuyGqMudyvKbkNx5dtNBNN59oKEAsPn", deriver.Derive(0, 0).String())
+	assert.Equal(t, "moHN13u4RoMxujdaPxvuaTaawgWZ3LaGyo", deriver.Derive(1, 0).String())
 }

--- a/main.go
+++ b/main.go
@@ -6,17 +6,14 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"strconv"
 	"strings"
-	"time"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/square/beancounter/balance"
+	"github.com/square/beancounter/beancounter"
 	"github.com/square/beancounter/deriver"
 	. "github.com/square/beancounter/utils"
-
-	"github.com/olekukonko/tablewriter"
 )
 
 var (
@@ -34,81 +31,6 @@ const (
 	mainnetDefaultServer = "electrum.petrkr.net:50002"
 	testnetDefaultServer = "electrum_testnet_unlimited.criptolayer.net:50102"
 )
-
-type totalBalance struct {
-	account       string
-	net           Network
-	xpubs         []string
-	lastAddresses [2]uint32
-	totalBalance  uint64
-	transactions  []transaction
-	balances      []addrBalance
-	// NOTE: maybe track unconfirmed balance and fees. We might want to also track each transaction's amount and whether
-	// it's a credit or debit.
-}
-
-type addrBalance struct {
-	path    string
-	addr    string
-	balance uint64
-}
-
-func (b *addrBalance) toCSV() string {
-	return b.path + "," + b.addr + "," + strconv.FormatUint(b.balance, 10)
-}
-
-func (b *addrBalance) toArray() []string {
-	return []string{b.path, b.addr, strconv.FormatUint(b.balance, 10)}
-}
-
-type transaction struct {
-	path string
-	addr string
-	hash string
-}
-
-func (t *transaction) toCSV() string {
-	return t.path + "," + t.addr + "," + t.hash
-}
-
-func (t *transaction) toArray() []string {
-	return []string{t.path, t.addr, t.hash}
-}
-
-func (tb *totalBalance) writeTransactions() {
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Path", "Address", "Transaction Hash"})
-
-	for _, tb := range tb.transactions {
-		table.Append(tb.toArray())
-	}
-	table.Render()
-	fmt.Printf("\n")
-}
-
-func (tb *totalBalance) writeSummary() {
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Total Balance", "Last Receive Index", "Last Change Index", "Report Time"})
-
-	table.Append([]string{
-		strconv.FormatUint(tb.totalBalance, 10),
-		strconv.FormatUint(uint64(tb.lastAddresses[0]-1), 10),
-		strconv.FormatUint(uint64(tb.lastAddresses[1]-1), 10),
-		time.Now().Format(time.RFC822)})
-	table.Render()
-	fmt.Printf("\n")
-}
-
-func (tb *totalBalance) writeBalances() {
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Path", "Address", "Balance"})
-
-	for _, tb := range tb.balances {
-		table.Append(tb.toArray())
-	}
-	table.Render()
-	fmt.Printf("\n")
-}
 
 func main() {
 	kingpin.Version("0.0.2")
@@ -144,57 +66,29 @@ func main() {
 
 	// NOTE: maybe allow to query various services like BlockCypher etc. based on
 	//       CLI options
-	b, err := balance.NewElectrumChecker(getServer())
+	checker, err := balance.NewElectrumChecker(getServer())
 	PanicOnError(err)
 
-	tb := &totalBalance{}
+	tb := beancounter.NewBalance(checker, deriver, *lookahead, *sleep)
 
-	for _, change := range []uint32{0, 1} {
-		tb.lastAddresses[change] = *lookahead
-		for i := uint32(0); i < tb.lastAddresses[change]; i++ {
-			addr := deriver.Derive(change, i)
-			p := fmt.Sprintf("m/%s/%d/%d/%d", coinType(net), *account, change, i)
-
-			fmt.Printf("Checking balance for %s %s ... ", p, addr)
-			resp, err := b.Fetch(addr)
-			PanicOnError(err)
-
-			tb.addBalance(resp, p, addr, i+*lookahead, change)
-			if resp.HasTransactions() {
-				fmt.Printf("%d %d\n", resp.Balance, tb.totalBalance)
-			} else {
-				fmt.Printf("∅\n")
-			}
-			time.Sleep(*sleep)
-		}
-	}
+	tb.Count()
 
 	fmt.Printf("\n")
-	tb.writeTransactions()
-	tb.writeBalances()
-	tb.writeSummary()
-	PanicOnError(err)
+	tb.WriteTransactions()
+	tb.WriteBalances()
+	tb.WriteSummary()
 }
 
-func (tb *totalBalance) addBalance(r *balance.Response, path, addr string, lastAddrIndex, change uint32) {
-	tb.totalBalance += r.Balance
-	if r.HasTransactions() {
-		tb.lastAddresses[change] = lastAddrIndex
-		tb.balances = append(tb.balances, addrBalance{path: path, addr: addr, balance: r.Balance})
-
-		for _, tx := range r.Transactions {
-			tb.transactions = append(tb.transactions, transaction{path: path, addr: addr, hash: tx.Hash})
-		}
+// pick a default server for each network if none provided
+func getServer() string {
+	if *addr != nil {
+		return (*addr).String()
 	}
-}
-
-// as per SLIP-0044 https://github.com/satoshilabs/slips/blob/master/slip-0044.md
-func coinType(n Network) string {
-	switch n {
-	case Mainnet:
-		return "0'"
-	case Testnet:
-		return "1'"
+	switch *network {
+	case "mainnet":
+		return mainnetDefaultServer
+	case "testnet":
+		return testnetDefaultServer
 	default:
 		panic("unreachable")
 	}
@@ -208,21 +102,6 @@ func pubKeyPrefix() string {
 		return "xpub"
 	case "testnet":
 		return "tpub"
-	default:
-		panic("unreachable")
-	}
-}
-
-// pick a default server for each network if none provided
-func getServer() string {
-	if *addr != nil {
-		return (*addr).String()
-	}
-	switch *network {
-	case "mainnet":
-		return mainnetDefaultServer
-	case "testnet":
-		return testnetDefaultServer
 	default:
 		panic("unreachable")
 	}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	checker, err := balance.NewElectrumChecker(getServer())
 	PanicOnError(err)
 
-	tb := beancounter.NewBalance(checker, deriver, *lookahead, *sleep)
+	tb := beancounter.NewCounter(checker, deriver, *lookahead, *sleep)
 
 	tb.Count()
 


### PR DESCRIPTION
- refactor most of code from `main.go` into its own package
- provide API for continuous (and concurrent) checking of balances for addresses via `Subscribe(addrCh <-chan *deriver.Address) <-chan *Response`