### PR TITLE
Handle closed channels in accounter logic

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -30,8 +30,6 @@ type Backend interface {
 	AddrResponses() <-chan *AddrResponse
 	TxResponses() <-chan *TxResponse
 
-	// Dec is super hacky. Need to find another wait to do this...
-	Dec()
 	Finish()
 }
 

--- a/backend/electrum/blockchain.go
+++ b/backend/electrum/blockchain.go
@@ -155,6 +155,10 @@ func NewNode(addr, port string, network utils.Network) (*Node, error) {
 	return n, nil
 }
 
+func (n *Node) Disconnect() error {
+	return n.transport.Shutdown()
+}
+
 func NodeIdent(addr, port string) string {
 	return fmt.Sprintf("%s|%s", addr, port)
 }

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -3,18 +3,19 @@ package reporter
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 )
 
 // Reporter tracks our progress while we are fetching data. It then spits out the balance and
 // various pieces of information.
 
 type Reporter struct {
-	AddressesScheduled uint32
-	AddressesFetched   uint32
-	TxScheduled        uint32
-	TxFetched          uint32
-	TxAfterFilter      int
-	Peers              int
+	addressesScheduled uint32
+	addressesFetched   uint32
+	txScheduled        uint32
+	txFetched          uint32
+	txAfterFilter      int32
+	peers              int32
 }
 
 var instance *Reporter
@@ -28,6 +29,78 @@ func GetInstance() *Reporter {
 }
 
 func (r *Reporter) Log(msg string) {
-	fmt.Printf("%d/%d %d/%d/%d %d: %s\n", r.AddressesScheduled, r.AddressesFetched,
-		r.TxScheduled, r.TxFetched, r.TxAfterFilter, r.Peers, msg)
+	fmt.Printf("%d/%d %d/%d/%d %d: %s\n", r.GetAddressesScheduled(), r.GetAddressesFetched(),
+		r.GetTxScheduled(), r.GetTxFetched(), r.GetTxAfterFilter(), r.GetPeers(), msg)
+}
+
+func (r *Reporter) IncAddressesFetched() {
+	atomic.AddUint32(&r.addressesFetched, 1)
+}
+
+func (r *Reporter) GetAddressesFetched() uint32 {
+	return atomic.LoadUint32(&r.addressesFetched)
+}
+
+func (r *Reporter) SetAddressesFetched(n uint32) {
+	atomic.StoreUint32(&r.addressesFetched, n)
+}
+
+func (r *Reporter) IncAddressesScheduled() {
+	atomic.AddUint32(&r.addressesScheduled, 1)
+}
+
+func (r *Reporter) GetAddressesScheduled() uint32 {
+	return atomic.LoadUint32(&r.addressesScheduled)
+}
+
+func (r *Reporter) SetddressesScheduled(n uint32) {
+	atomic.StoreUint32(&r.addressesScheduled, n)
+}
+
+func (r *Reporter) IncTxFetched() {
+	atomic.AddUint32(&r.txFetched, 1)
+}
+
+func (r *Reporter) GetTxFetched() uint32 {
+	return atomic.LoadUint32(&r.txFetched)
+}
+
+func (r *Reporter) SetTxFetched(n uint32) {
+	atomic.StoreUint32(&r.txFetched, n)
+}
+
+func (r *Reporter) IncTxScheduled() {
+	atomic.AddUint32(&r.txScheduled, 1)
+}
+
+func (r *Reporter) GetTxScheduled() uint32 {
+	return atomic.LoadUint32(&r.txScheduled)
+}
+
+func (r *Reporter) SetTxScheduled(n uint32) {
+	atomic.StoreUint32(&r.txScheduled, n)
+}
+
+func (r *Reporter) IncTxAfterFilter() {
+	atomic.AddInt32(&r.txAfterFilter, 1)
+}
+
+func (r *Reporter) GetTxAfterFilter() int32 {
+	return atomic.LoadInt32(&r.txAfterFilter)
+}
+
+func (r *Reporter) SetTxAfterFilter(n int32) {
+	atomic.StoreInt32(&r.txAfterFilter, n)
+}
+
+func (r *Reporter) IncPeers() {
+	atomic.AddInt32(&r.peers, 1)
+}
+
+func (r *Reporter) GetPeers() int32 {
+	return atomic.LoadInt32(&r.peers)
+}
+
+func (r *Reporter) SetPeers(n int32) {
+	atomic.StoreInt32(&r.peers, n)
 }


### PR DESCRIPTION
Some backends might close their channels and accounter should know how
to deal with that. When a closed channel is bein read, a zero value is returned
immediately and when a nil channel is read it blocks forever. Select
skips the channels that are blocking and hence nil channels are an
efficient way to ignore channels that are done.

Also, addresses race conditions in the reporter where reads and writes
to reporter's fields were not synchronized. Now adding, getting and
setting a value is atomic.