### PR TITLE
Add test coverage to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ go:
   - '1.10.x'
   - '1.x'
 
-script:
-  - go test -v ./...
+before_install:
+  - go get github.com/mattn/goveralls
 
+script:
+  - go test -v ./... -coverprofile coverage.out
+
+after_success:
+  - $HOME/gopath/bin/goveralls -coverprofile coverage.out -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Beancounter
 ==========
 
-[![license](http://img.shields.io/badge/license-apache_2.0-blue.svg?style=flat)](https://raw.githubusercontent.com/square/beancounter/master/LICENSE) [![travis](https://img.shields.io/travis/com/square/beancounter.svg?maxAge=3600&logo=travis&label=travis)](https://travis-ci.com/square/beancounter) [![report](https://goreportcard.com/badge/github.com/square/beancounter)](https://goreportcard.com/report/github.com/square/beancounter)
+[![license](http://img.shields.io/badge/license-apache_2.0-blue.svg?style=flat)](https://raw.githubusercontent.com/square/beancounter/master/LICENSE) [![travis](https://img.shields.io/travis/com/square/beancounter.svg?maxAge=3600&logo=travis&label=travis)](https://travis-ci.com/square/beancounter)
+[![coverage](https://coveralls.io/repos/github/square/beancounter/badge.svg?branch=master)](https://coveralls.io/r/square/beancounter) [![report](https://goreportcard.com/badge/github.com/square/beancounter)](https://goreportcard.com/report/github.com/square/beancounter)
 
 Beancounter is a command line utility to audit the balance of Hierarchical Deterministic (HD) wallets. The tool is
 designed to scale and work for wallets with a large number of addresses or a large number of transactions.


### PR DESCRIPTION
Note: `go test -v ./... -coverprofile coverage.out` (merging cover outputs from multiple packages works in Go 1.10 and higher, but since we assume at least Go 1.10 in `.travis.yml` file we're good)