### PR TITLE
Implement backend.ChainHeight()

### DIFF
--- a/accounter/accounter_test.go
+++ b/accounter/accounter_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestProcessTransactions(t *testing.T) {
 	a := Accounter{
-		maxHeight:    100,
+		blockHeight:  100,
 		transactions: make(map[string]transaction),
 	}
 	// https://api.blockcypher.com/v1/btc/main/txs/38f6366700f12dc902718ab5222c8ae67a4514ed07ee8aea364feec22bf6424f?limit=50&includeHex=true

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -7,17 +7,19 @@ import (
 // Backend is an interface which abstracts different types of backends.
 //
 // The Backends are responsible for fetching all the transactions related to an address.
-// For each transaction, the Backend must also grab:
+// For each transaction, the Backend must grab:
 // - the height
 // - the raw transaction bytes
 //
-// The Backend doesn't keep much state. It pushes the data in the AddrResponses and TxResponses
-// channels, which the Accounter reads from. A given transaction can (and often does) involve
-// multiple addresses from the same wallet. The Backend maintains a small map to dedup fetches.
+// In addition, the backend must know the chain height. The backend is allowed to fetch this value
+// once (at startup) and cache it.
+//
+// In general, we tried to keep the backends minimal and move as much (common) logic as possible
+// into the accounter.
 //
 // There are a few differences between Electrum and Btcd (and potentially any other Backend we
-// decide to add in the future). For instance, Electrum returns  the block height when fetching all
-// the transactions for a given address, but Btcd doesn't. On  the other hand, Btcd returns the raw
+// decide to add in the future). For instance, Electrum returns the block height when fetching all
+// the transactions for a given address, but Btcd doesn't. On the other hand, Btcd returns the raw
 // transaction information right away but Electrum requires additional requests.
 //
 // Because of these differences, the Backend exposes a Finish() method. This method allows the
@@ -28,6 +30,8 @@ type Backend interface {
 	AddrRequest(addr *deriver.Address)
 	AddrResponses() <-chan *AddrResponse
 	TxResponses() <-chan *TxResponse
+
+	ChainHeight() uint32
 
 	Finish()
 }

--- a/backend/common.go
+++ b/backend/common.go
@@ -8,8 +8,13 @@ import (
 // backends marshal/unmarshal address and transaction data
 
 type index struct {
+	Metadata     metadata      `json:"metadata"`
 	Addresses    []address     `json:"addresses"`
 	Transactions []transaction `json:"transactions"`
+}
+
+type metadata struct {
+	Height uint32 `json:"height"`
 }
 
 type address struct {

--- a/backend/electrum/blockchain.go
+++ b/backend/electrum/blockchain.go
@@ -113,6 +113,11 @@ type Peer struct {
 	Features []string
 }
 
+type Header struct {
+	Height uint32 `json:"height"`
+	Hex    string `json:"hex"`
+}
+
 func NewNode(addr, port string, network utils.Network) (*Node, error) {
 	n := &Node{}
 	var a string
@@ -212,6 +217,19 @@ func (n *Node) BlockchainTransactionGet(txid string) (string, error) {
 	var hex string
 	err := n.request("blockchain.transaction.get", []interface{}{txid, false}, &hex)
 	return hex, err
+}
+
+// Subscribe to receive block headers when a new block is found.
+//
+// Note: there's no way to unsubscribe, and the rest of this code doesn't know how to deal with
+// notifications. It is advisable to only call this method once and disconnect/reconnect after
+// getting the block height.
+//
+// https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-headers-subscribe
+func (n *Node) BlockchainHeadersSubscribe() (*Header, error) {
+	var header Header
+	err := n.request("blockchain.headers.subscribe", []interface{}{true}, &header)
+	return &header, err
 }
 
 // ServerPeersSubscribe requests peers from a server.

--- a/backend/fixture_backend.go
+++ b/backend/fixture_backend.go
@@ -32,6 +32,8 @@ type FixtureBackend struct {
 	doneCh chan bool
 
 	readOnly bool
+
+	height uint32
 }
 
 // NewFixtureBackend returns a new FixtureBackend structs or errors.
@@ -83,6 +85,10 @@ func (b *FixtureBackend) TxResponses() <-chan *TxResponse {
 // Finish informs the backend to stop doing its work.
 func (b *FixtureBackend) Finish() {
 	close(b.doneCh)
+}
+
+func (b *FixtureBackend) ChainHeight() uint32 {
+	return b.height
 }
 
 func (b *FixtureBackend) processRequests() {
@@ -166,6 +172,8 @@ func (b *FixtureBackend) loadFromFile(f *os.File) error {
 	if err != nil {
 		return err
 	}
+
+	b.height = cachedData.Metadata.Height
 
 	for _, addr := range cachedData.Addresses {
 		a := AddrResponse{

--- a/backend/recorder_backend.go
+++ b/backend/recorder_backend.go
@@ -84,6 +84,10 @@ func (rb *RecorderBackend) Finish() {
 	}
 }
 
+func (rb *RecorderBackend) ChainHeight() uint32 {
+	return rb.backend.ChainHeight()
+}
+
 func (rb *RecorderBackend) processRequests() {
 	backendAddrResponses := rb.backend.AddrResponses()
 	backendTxResponses := rb.backend.TxResponses()
@@ -115,7 +119,7 @@ func (rb *RecorderBackend) processRequests() {
 }
 
 func (rb *RecorderBackend) writeToFile() error {
-	cachedData := index{Addresses: []address{}, Transactions: []transaction{}}
+	cachedData := index{Metadata: metadata{}, Addresses: []address{}, Transactions: []transaction{}}
 
 	reporter.GetInstance().Log(fmt.Sprintf("writing data to %s\n ...", rb.outputFilepath))
 	f, err := os.Create(rb.outputFilepath)
@@ -123,6 +127,8 @@ func (rb *RecorderBackend) writeToFile() error {
 		return err
 	}
 	defer f.Close()
+
+	cachedData.Metadata.Height = rb.ChainHeight()
 
 	for addr, addrResp := range rb.addrIndex {
 		a := address{


### PR DESCRIPTION
The code already existed for Btcd, but the Electrum backend needed some
work.

Exposing the chain height is useful for two reasons:
1. it enables us to make the --block-height parameter optional and
default to current height - 6.
2. it enables binary searching for a block given a timestamp.