### PR TITLE
Fix ability to specify backend server and default server

### DIFF
--- a/backend/btcd_backend.go
+++ b/backend/btcd_backend.go
@@ -57,9 +57,9 @@ const (
 // BtcdBackend is meants to connect to a personal Btcd node (because public nodes don't expose the
 // API we need). There's no TLS support. If your node is not co-located with Beancounter, we
 // recommend wrapping your connection in a ssh or other secure tunnel.
-func NewBtcdBackend(hostPort, user, pass string, network utils.Network) (*BtcdBackend, error) {
+func NewBtcdBackend(host, port, user, pass string, network utils.Network) (*BtcdBackend, error) {
 	connCfg := &rpcclient.ConnConfig{
-		Host:         hostPort,
+		Host:         fmt.Sprintf("%s:%s", host, port),
 		User:         user,
 		Pass:         pass,
 		HTTPPostMode: true, // Bitcoin core only supports HTTP POST mode

--- a/backend/electrum/blockchain.go
+++ b/backend/electrum/blockchain.go
@@ -139,6 +139,7 @@ func NewNode(addr, port string, network utils.Network) (*Node, error) {
 	}
 
 	if port[0] == 't' {
+		// TCP
 		var p string
 		if len(port) == 1 {
 			p = defaultTCP
@@ -147,6 +148,7 @@ func NewNode(addr, port string, network utils.Network) (*Node, error) {
 		}
 		t, err = NewTCPTransport(fmt.Sprintf("%s:%s", a, p))
 	} else if port[0] == 's' {
+		// TLS
 		var p string
 		if len(port) == 1 {
 			p = defaultSSL
@@ -154,6 +156,8 @@ func NewNode(addr, port string, network utils.Network) (*Node, error) {
 			p = port[1:]
 		}
 		t, err = NewSSLTransport(fmt.Sprintf("%s:%s", a, p))
+	} else {
+		panic(fmt.Sprintf("port (%s) must start with t or s", port))
 	}
 
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/btcsuite/btcd/chaincfg"
 )
@@ -24,6 +25,14 @@ func Max(num uint32, nums ...uint32) uint32 {
 }
 
 type Network string
+type Backend string
+
+const (
+	Mainnet  Network = "mainnet"
+	Testnet  Network = "testnet"
+	Electrum Backend = "electrum"
+	Btcd     Backend = "btcd"
+)
 
 // ChainConfig returns a given chaincfg.Params for a given Network
 func (n Network) ChainConfig() *chaincfg.Params {
@@ -94,7 +103,34 @@ func VerifyMandN(m int, n int) error {
 	return nil
 }
 
-const (
-	Mainnet Network = "mainnet"
-	Testnet Network = "testnet"
-)
+// Picks a default server for electrum or localhost for btcd
+// Returns a pair of hostname:port (or pseudo-port for electrum)
+func GetDefaultServer(network Network, backend Backend, addr string) (string, string) {
+	if addr != "" {
+		host, port, err := net.SplitHostPort(addr)
+		PanicOnError(err)
+		return host, port
+	}
+	switch backend {
+	case Electrum:
+		switch network {
+		case "mainnet":
+			return "electrum.petrkr.net", "s50002"
+		case "testnet":
+			return "electrum_testnet_unlimited.criptolayer.net", "s50102"
+		default:
+			panic("unreachable")
+		}
+	case Btcd:
+		switch network {
+		case "mainnet":
+			return "localhost", "8334"
+		case "testnet":
+			return "localhost", "18334"
+		default:
+			panic("unreachable")
+		}
+	default:
+		panic("unreachable")
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -76,3 +76,29 @@ func TestVerifyMandN(t *testing.T) {
 	assert.Nil(t, VerifyMandN(5, 20))
 	assert.Nil(t, VerifyMandN(20, 20))
 }
+
+func TestGetDefaultServer(t *testing.T) {
+	host, port := GetDefaultServer(Testnet, Electrum, "foobar:s1234")
+	assert.Equal(t, "foobar", host)
+	assert.Equal(t, "s1234", port)
+
+	host, port = GetDefaultServer(Testnet, Electrum, "192.0.2.5:s1234")
+	assert.Equal(t, "192.0.2.5", host)
+	assert.Equal(t, "s1234", port)
+
+	host, port = GetDefaultServer(Testnet, Electrum, "[2001:db8::1]:s1234")
+	assert.Equal(t, "2001:db8::1", host)
+	assert.Equal(t, "s1234", port)
+
+	host, port = GetDefaultServer(Testnet, Btcd, "foobar:1234")
+	assert.Equal(t, "foobar", host)
+	assert.Equal(t, "1234", port)
+
+	host, port = GetDefaultServer(Testnet, Electrum, "")
+	assert.NotEqual(t, "localhost", host)
+	assert.Equal(t, "s50102", port)
+
+	host, port = GetDefaultServer(Testnet, Btcd, "")
+	assert.Equal(t, "localhost", host)
+	assert.Equal(t, "18334", port)
+}


### PR DESCRIPTION
For electrum, the address must be HOST:tPORT or HOST:sPORT. If addr is
not specified, we default to the initial hardcoded node.

For btcd, the address must be HOST:PORT. If addr is not specifed, we
default to localhost:8334.

Fixes https://github.com/square/beancounter/issues/32